### PR TITLE
Fix the bev image generation script and proper training from scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+datasets
+__pycache__
+cache
+*.png
+runs

--- a/datasets/gen_bev_images.py
+++ b/datasets/gen_bev_images.py
@@ -45,7 +45,7 @@ def getBEV(all_points): #N*3
 
     max_pixel = np.max(np.max(mat_global_image))
 
-    mat_global_image[mat_global_image<=1] = 0  
+    # mat_global_image[mat_global_image<=1] = 0  
     mat_global_image = mat_global_image*10
     
     mat_global_image[np.where(mat_global_image>255)]=255

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ def get_args():
     parser.add_argument('--cachePath', type=str, default='./cache/', help='Path to save cache to.')
 
 
-    parser.add_argument('--load_from', type=str, default='runs/Aug08_10-17-29', help='Path to load checkpoint from, for resuming training or testing.')
+    parser.add_argument('--load_from', type=str, default='', help='Path to load checkpoint from, for resuming training or testing.')
     parser.add_argument('--ckpt', type=str, default='best', 
             help='Load_from from latest or best checkpoint.', choices=['latest', 'best'])
     
@@ -253,7 +253,7 @@ if __name__ == "__main__":
     model = model.cuda()
     
     # initialize netvlad with pre-trained or cluster
-    if opt.load_from:
+    if opt.load_from != '':
         if opt.ckpt.lower() == 'latest':
             resume_ckpt = join(opt.load_from,  'checkpoint.pth.tar')
         elif opt.ckpt.lower() == 'best':


### PR DESCRIPTION
Hi, Thanks for this excellent work! I was trying to reproduce the results and came across 2 minor issues that I like to share the quick fixes, in case helpful to others
1. in the bev image generation script, since point cloud is downsampled by voxel size 0.4, cells in flat region often only gain single hit. The current logic clamps hits <=1 to zero suppressing valid measurements. Removing the clamping yield consistent bev image with the provided data.
2. by default training resumes from a previsous run, however to train from scratch, the descriptor initialization is unintentionally skipped